### PR TITLE
updated script to use docker compose V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ ./run_gochain.sh pause
 $ ./run_gochain.sh unpause
 ```
 
-## Using Docker-Compose
+## Using Docker Compose
 
 There are two docker Compose files as the following.
   - `compose-single.yml`: run a single gochain node as the previous script example
@@ -90,11 +90,11 @@ There are two docker Compose files as the following.
 
 #### For a single gochain node:
 ```
-$ docker-compose -f compose-single.yml up -d
+$ docker compose -f compose-single.yml up -d
 Creating network "gochain-local_default" with the default driver
 Creating gochain-iconee ... done
 
-$ docker-compose -f compose-single.yml ps
+$ docker compose -f compose-single.yml ps
      Name                   Command               State                              Ports
 ----------------------------------------------------------------------------------------------------------------------
 gochain-iconee   /entrypoint /bin/sh -c /go ...   Up      8080/tcp, 9080/tcp, 0.0.0.0:9082->9082/tcp,:::9082->9082/tcp
@@ -102,14 +102,14 @@ gochain-iconee   /entrypoint /bin/sh -c /go ...   Up      8080/tcp, 9080/tcp, 0.
 
 #### For multiple gochain nodes:
 ```
-$ docker-compose -f compose-multi.yml up -d
+$ docker compose -f compose-multi.yml up -d
 Creating network "gochain-local_default" with the default driver
 Creating gochain-local_node3_1 ... done
 Creating gochain-local_node0_1 ... done
 Creating gochain-local_node1_1 ... done
 Creating gochain-local_node2_1 ... done
 
-$ docker-compose -f compose-multi.yml ps
+$ docker compose -f compose-multi.yml ps
         Name                       Command               State                         Ports
 -------------------------------------------------------------------------------------------------------------------
 gochain-local_node0_1   /entrypoint /bin/sh -c /go ...   Up      8080/tcp, 0.0.0.0:9080->9080/tcp,:::9080->9080/tcp
@@ -121,12 +121,12 @@ gochain-local_node3_1   /entrypoint /bin/sh -c /go ...   Up      8080/tcp, 0.0.0
 ### Stop and remove the container
 
 ```
-$ docker-compose -f compose-single.yml down
+$ docker compose -f compose-single.yml down
 ```
 
 or
 ```
-$ docker-compose -f compose-multi.yml down
+$ docker compose -f compose-multi.yml down
 ```
 
 ## Persistence of Data
@@ -142,7 +142,7 @@ After starting the local gochain nodes (single or multi), run the following comm
 
 ```
 $ cd tracker
-$ docker-compose up -d
+$ docker compose up -d
 Creating network "tracker_default" with the default driver
 Creating tracker_mysql ... done
 Creating tracker_app   ... done

--- a/run_gochain.sh
+++ b/run_gochain.sh
@@ -15,26 +15,26 @@ fi
 
 startDocker() {
     echo ">>> START with compose-$1.yml"
-    docker-compose -f compose-$1.yml up -d
+    docker compose -f compose-$1.yml up -d
 }
 
 stopDocker() {
     echo ">>> STOP with compose-$1.yml"
-    docker-compose -f compose-$1.yml down
+    docker compose -f compose-$1.yml down
 }
 
 pauseDocker() {
     echo ">>> PAUSE with compose-$1.yml"
-    docker-compose -f compose-$1.yml pause
+    docker compose -f compose-$1.yml pause
 }
 
 unpauseDocker() {
     echo ">>> UNPAUSE with compose-$1.yml"
-    docker-compose -f compose-$1.yml unpause
+    docker compose -f compose-$1.yml unpause
 }
 
 psDocker() {
-    docker-compose -f compose-$1.yml ps
+    docker compose -f compose-$1.yml ps
 }
 
 case "$CMD" in

--- a/tracker/Makefile
+++ b/tracker/Makefile
@@ -2,13 +2,13 @@ help:
 	@echo "make [up|down|clear]"
 
 up:
-	docker-compose up -d
+	docker compose up -d
 
 down:
-	docker-compose down
+	docker compose down
 
 ps:
-	docker-compose ps
+	docker compose ps
 
 clean:
 	sudo rm -rf data logs score


### PR DESCRIPTION
Updated `./run_gochain.sh` script to use docker compose V2

ran command locally with `docker compose` V2 and all commands execute successfully
```bash
$ sudo ./run_gochain.sh start
>>> START with compose-single.yml
[+] Running 2/2
 ⠿ Network gochain-local_default  Creat...                                 0.1s
 ⠿ Container gochain-iconee       Started                                  0.5s

$ sudo ./run_gochain.sh pause
>>> PAUSE with compose-single.yml
[+] Running 1/0
 ⠿ Container gochain-iconee  Paused                                        0.0s

$ sudo ./run_gochain.sh unpause
>>> UNPAUSE with compose-single.yml
[+] Running 1/0
 ⠿ Container gochain-iconee  Unpaused                                      0.0s

$ sudo ./run_gochain.sh ps
NAME                COMMAND                  SERVICE             STATUS              PORTS
gochain-iconee      "/entrypoint /bin/sh…"   gochain-iconee      running             0.0.0.0:9082->9082/tcp, :::9082->9082/tcp

$ sudo ./run_gochain.sh stop
>>> STOP with compose-single.yml
[+] Running 2/2
 ⠿ Container gochain-iconee       Removed                                 10.4s
 ⠿ Network gochain-local_default  Remov...                                 0.1s
``` 