### PR TITLE
feat: adds the docker image from iconcommunity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,6 @@ A collection of helper scripts to run gochain docker container as a local networ
 - Download and install Docker
   - [Get Docker](https://docs.docker.com/get-docker/)
 
-- `goloop/gochain-icon` docker image
-  - Build
-    ```
-    $ git clone https://github.com/icon-project/goloop.git
-    $ cd goloop
-    $ make gochain-icon-image
-    ```
-  - Verify the generated image
-    ```
-    $ docker images goloop/gochain-icon
-    REPOSITORY            TAG       IMAGE ID       CREATED         SIZE
-    goloop/gochain-icon   latest    74676aec69ef   2 minutes ago   513MB
-    ```
-
 ## Usage
 
 You can start or stop the docker container using the following script. You can also use [docker compose](#using-docker-compose) to start or stop the container.

--- a/compose-multi.yml
+++ b/compose-multi.yml
@@ -1,6 +1,6 @@
 services:
     node0:
-        image: goloop/gochain-icon:latest
+        image: iconcommunity/gochain-icon:latest
         volumes:
             - ./data/multi:/goloop/data
             - ./data/governance:/goloop/data/gov
@@ -14,7 +14,7 @@ services:
         ports:
             - "9080:9080"
     node1:
-        image: goloop/gochain-icon:latest
+        image: iconcommunity/gochain-icon:latest
         volumes:
             - ./data/multi:/goloop/data
             - ./data/governance:/goloop/data/gov
@@ -28,7 +28,7 @@ services:
         ports:
             - "9081:9080"
     node2:
-        image: goloop/gochain-icon:latest
+        image: iconcommunity/gochain-icon:latest
         volumes:
             - ./data/multi:/goloop/data
             - ./data/governance:/goloop/data/gov
@@ -42,7 +42,7 @@ services:
         ports:
             - "9082:9080"
     node3:
-        image: goloop/gochain-icon:latest
+        image: iconcommunity/gochain-icon:latest
         volumes:
             - ./data/multi:/goloop/data
             - ./data/governance:/goloop/data/gov

--- a/compose-single.yml
+++ b/compose-single.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
     gochain-iconee:
         container_name: gochain-iconee
-        image: goloop/gochain-icon:latest
+        image: iconcommunity/gochain-icon:latest
         env_file:
             - ./data/single/iconee.env
         volumes:


### PR DESCRIPTION
**Changes**

Simplified the installation by using the upstream docker image instead of building locally
The docker image can be found here - https://hub.docker.com/r/iconcommunity/gochain-icon 